### PR TITLE
fix banner height and positioning of overlay on mobile

### DIFF
--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -13,6 +13,7 @@ const Banner = (props: BannerProps) => {
                     src={src}
                     alt={alt}
                     className="mx-auto"
+                    style={{ minHeight: '70vh' }}
                 />
                 <div className="overlay-image"></div>
                 <div className='overlay-text flex-column text-center'>

--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -3,7 +3,7 @@ import { graphql, Link, useStaticQuery } from 'gatsby'
 import Img from 'gatsby-image/withIEPolyfill'
 import { ImageProps, ImageFluidNodeProps } from '../types'
 
-const Image = ({ src, to, alt, ...rest }: ImageProps) => {
+const Image = ({ src, to, alt, style, ...rest }: ImageProps) => {
     const data = useStaticQuery(graphql`
     query {
       images: allFile(
@@ -36,11 +36,11 @@ const Image = ({ src, to, alt, ...rest }: ImageProps) => {
     const { node: { childImageSharp, publicURL, extension } = {} } = match as ImageFluidNodeProps;
 
     if (extension === 'svg' || !childImageSharp) {
-        const svgImage = <img src={publicURL} alt={alt} {...rest} />
+        const svgImage = <img src={publicURL} alt={alt} style={style} {...rest} />
         return to ? <Link to={to}>{svgImage}</Link> : svgImage;
     }
 
-    const renderedImage = <Img fluid={childImageSharp.fluid} objectFit="cover" objectPosition="50% 50%" alt={alt} {...rest} />;
+    const renderedImage = <Img fluid={childImageSharp.fluid} objectFit="cover" objectPosition="50% 50%" alt={alt} style={style} {...rest} />;
     return to ? <Link to={to}>{renderedImage}</Link> : renderedImage;
 };
 

--- a/src/components/social.tsx
+++ b/src/components/social.tsx
@@ -10,7 +10,7 @@ import { SocialLinkProps } from '../types'
 export default function Header({ color, key, size }: SocialLinkProps) {
     return (
         <IconContext.Provider value={{ size: size, style: { margin: '.5rem' } }}>
-            <div className='d-flex justify-content-center'>
+            <div className='d-flex justify-content-center flex-wrap'>
                 <NewTabLink className={linkColor(color) + ' nav-padding-social'} href={urls.linkedin} key={urls.linkedin + ' ' + key}><FaLinkedin /></NewTabLink>
                 <NewTabLink className={linkColor(color) + ' nav-padding-social'} href={urls.github} key={urls.github + ' ' + key}><FaGithub /></NewTabLink>
                 <NewTabLink className={linkColor(color) + ' nav-padding-social'} href={'mailto:' + urls.email} key={urls.email + ' ' + key}><MdMail /></NewTabLink>

--- a/src/styles/site.scss
+++ b/src/styles/site.scss
@@ -131,7 +131,6 @@ div.card {
         border-radius: .5rem;
         color: $white;
         width: 80%;
-        padding: 2rem;
         display: flex;
         flex-direction: column;
         justify-content: center;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,5 +1,6 @@
 import { ReactElement, ReactNode } from 'react'
 import { FixedObject, FluidObject } from 'gatsby-image'
+import CSS from 'csstype'
 
 export type AuthorProps = {
     name: string
@@ -79,6 +80,7 @@ export type ImageProps = {
     className?: string
     to?: string
     src: string
+    style?: CSS.Properties
 }
 
 export type LabelProps = {


### PR DESCRIPTION
- Set minimum banner height to 70vw.
- Removed padding of text-overlay class.
- Added flex-wrap to social icons.

Closes issue #9 